### PR TITLE
Fix dependency issue for watch.

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 	"dependencies": {
 		"colors": "0.6.2",
 		"lodash": "2.4.1",
-		"watch": "0.11.1",
+		"watch": "0.11.0",
 		"uglify-js": "2.4.15"
 	},
 	"scripts": {


### PR DESCRIPTION
Error: version not found: watch@0.11.1

Setting the watch version to 0.11.0 would fix the issue.
